### PR TITLE
fix warnings with latest v

### DIFF
--- a/examples/Games/1-Minesweeper/border_panels.v
+++ b/examples/Games/1-Minesweeper/border_panels.v
@@ -18,12 +18,12 @@ fn (app &App) side_panel() &ui.Panel {
 	p.subscribe_event('draw', fn (mut e ui.DrawEvent) {
 		p := e.target
 		e.ctx.gg.draw_rect_filled(p.x, p.y, p.width, p.height, gx.rgb(192, 192, 192))
-		
+
 		ph := e.target.parent.height
 		pw := e.target.parent.width
 
 		dif := (pw - ph) / 2
-		
+
 		if dif > 0 {
 			e.target.width = dif
 		} else {

--- a/examples/VideoPlayer/src/main.v
+++ b/examples/VideoPlayer/src/main.v
@@ -5,12 +5,12 @@ import gg
 import sync
 
 // import sokol.gfx
-const (
-	c_win_width     = 640 // 1280
-	c_win_height    = 360 // 720
-	c_win_font_size = 30
-	resolution      = [c_win_width, c_win_height]
-)
+const c_win_width = 640 // 1280
+
+const c_win_height = 360 // 720
+
+const c_win_font_size = 30
+const resolution = [c_win_width, c_win_height]
 
 //
 @[heap]

--- a/src/deprecated_stuff.v
+++ b/src/deprecated_stuff.v
@@ -19,7 +19,7 @@ pub fn button_with_icon(icon int, conf ButtonConfig) &Button {
 pub fn menuitem(text string) &MenuItem {
 	return &MenuItem{
 		text: text
-		icon: 0
+		icon: unsafe { nil }
 		click_event_fn: fn (mut win Window, item MenuItem) {}
 	}
 }

--- a/src/image.v
+++ b/src/image.v
@@ -40,7 +40,7 @@ pub fn Image.new(c ImgConfig) &Image {
 pub fn image_from_byte_array_with_size(mut w Window, b []u8, width int, h int) &Image {
 	mut img := &Image{
 		text: ''
-		img: 0
+		img: unsafe { nil }
 		width: width
 		height: h
 	}

--- a/src/modal.v
+++ b/src/modal.v
@@ -36,7 +36,7 @@ pub fn Modal.new(c ModalConfig) &Modal {
 		needs_init: true
 		in_width: 500
 		in_height: 300
-		close: 0
+		close: unsafe { nil }
 	}
 }
 

--- a/src/page.v
+++ b/src/page.v
@@ -37,7 +37,7 @@ pub fn Page.new(c PageCfg) &Page {
 		needs_init: true
 		text_cfg: draw_cfg()
 		in_height: 300
-		close: 0
+		close: unsafe { nil }
 	}
 }
 

--- a/src/panel.v
+++ b/src/panel.v
@@ -3,9 +3,7 @@ module iui
 import gx
 import math
 
-const (
-	nill = unsafe { nil }
-)
+const nill = unsafe { nil }
 
 // Layout
 // TODO: Add BorderLayout, Box Layout, Flow Layout, Grid Layout,
@@ -44,13 +42,11 @@ pub fn BorderLayout.new(c BorderLayoutConfig) BorderLayout {
 	}
 }
 
-pub const (
-	borderlayout_north  = 0
-	borderlayout_west   = 1
-	borderlayout_east   = 2
-	borderlayout_south  = 3
-	borderlayout_center = 4
-)
+pub const borderlayout_north = 0
+pub const borderlayout_west = 1
+pub const borderlayout_east = 2
+pub const borderlayout_south = 3
+pub const borderlayout_center = 4
 
 fn is_nil(a voidptr) bool {
 	return isnil(a)

--- a/src/textfield.v
+++ b/src/textfield.v
@@ -3,9 +3,7 @@ module iui
 import gx
 import gg
 
-const (
-	numbers_val = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.']
-)
+const numbers_val = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.']
 
 // TextField Component - Single line text input
 pub struct TextField {

--- a/src/ui.v
+++ b/src/ui.v
@@ -311,12 +311,12 @@ pub fn (mut win Window) run() {
 
 pub fn Window.new(cfg &WindowConfig) &Window {
 	mut win := &Window{
-		gg: 0
+		gg: unsafe { nil }
 		theme: cfg.theme
-		bar: 0
+		bar: unsafe { nil }
 		config: cfg
 		font_size: cfg.font_size
-		graphics_context: 0
+		graphics_context: unsafe { nil }
 	}
 
 	blank_draw_event_fn(mut win, &Component_A{})

--- a/src/ui.v
+++ b/src/ui.v
@@ -7,9 +7,7 @@ import time
 import os
 import os.font
 
-pub const (
-	version = '0.0.20'
-)
+pub const version = '0.0.20'
 
 pub fn default_font() string {
 	$if emscripten ? {

--- a/src/ui_on_event.v
+++ b/src/ui_on_event.v
@@ -68,7 +68,8 @@ fn (mut app Window) check_box(key gg.KeyCode, e &gg.Event, mut a Component) bool
 			app.check_box(key, e, mut comm)
 		}
 	}
-	if mut a is VBox || mut a is HBox || mut a is Titlebox || mut a is SplitView || mut a is InternalFrame {
+	if mut a is VBox || mut a is HBox || mut a is Titlebox || mut a is SplitView
+		|| mut a is InternalFrame {
 		for mut comm in a.children {
 			if app.check_box(key, e, mut comm) {
 				return true


### PR DESCRIPTION
Fix #6 .
This PR fixes some warnings, that latest V produces, when doing `v .` in https://github.com/pisaiah/vpaint .

Details:
- **fix warnings with latest V, change `field_name: 0` to `field_name: unsafe { nil }`**
- **run `v fmt -w .`**
